### PR TITLE
Rename doc to docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ format:
 
 doc:
 	@printf "$(YELLOW)Generating documentations..$(DEFAULT)\n"
-	@asciidoctor doc/README.adoc -o doc/index.html
+	@asciidoctor docs/README.adoc -o docs/index.html
 
 clean:
 	@$(RM) $(OBJD)

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -17,7 +17,7 @@ obj:: Objet, for compiled source code
 
 === The documentation
 
-doc:: Documentation folder
+docs:: Documentation folder
 
 === The tester
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -499,7 +499,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h3 id="_the_documentation">1.2. The documentation</h3>
 <div class="dlist">
 <dl>
-<dt class="hdlist1">doc</dt>
+<dt class="hdlist1">docs</dt>
 <dd>
 <p>Documentation folder</p>
 </dd>


### PR DESCRIPTION
### Why ?

For using GitHub pages, we have to name the documentation folder `docs` and not `doc` 