### PR TITLE
created a help message

### DIFF
--- a/src/arguments/check_argc_number.cpp
+++ b/src/arguments/check_argc_number.cpp
@@ -1,7 +1,17 @@
+#include <iostream>
+
+static void
+print_help(void)
+{
+	std::cerr << "Usage: webserv [CONFIGURATION_FILE]" << std::endl;
+}
+
 int
 check_argc_number(int argc)
 {
 	if (argc == 2)
 		return 0;
+
+	print_help();
 	return 1;
 }


### PR DESCRIPTION
### Usage message

This message is printed when the user doesn't put 1 argument.

I created this message from `grep` message
```
# (green): means that last command returned 0
# (red)  : means that last command didn't return 0
$(green) ./webserv
Usage: webserv [CONFIGURATION_FILE]
$(red) grep
usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
$(red)
```