### PR TITLE
Framework miscellaneous changes

### DIFF
--- a/test/framework/inc/Unit_test.hpp
+++ b/test/framework/inc/Unit_test.hpp
@@ -18,7 +18,7 @@ class Unit_test
 
 	void load_test(std::string const, int (*)(void));
 	int	 launch_tests(void);
-	void _last_line(void);
+	int	 _last_line(void);
 };
 
 #endif /* UNIT_TEST_HPP */

--- a/test/framework/src/Result.cpp
+++ b/test/framework/src/Result.cpp
@@ -1,4 +1,5 @@
 #include "Result.hpp"
+#include <sys/wait.h>
 
 void
 Result::print_result(void) const

--- a/test/framework/src/Test.cpp
+++ b/test/framework/src/Test.cpp
@@ -1,4 +1,5 @@
 #include "Test.hpp"
+#include <stdlib.h>
 
 Test::Test(std::string const &name, int (*function_ptr)(void)) : _name(name), _function_ptr(function_ptr) {}
 

--- a/test/framework/src/Unit_test.cpp
+++ b/test/framework/src/Unit_test.cpp
@@ -1,4 +1,5 @@
 #include "Unit_test.hpp"
+#include <algorithm>
 
 Unit_test::Unit_test(std::string const &name) : unit_name(name) {}
 

--- a/test/framework/src/Unit_test.cpp
+++ b/test/framework/src/Unit_test.cpp
@@ -16,7 +16,7 @@ do_test(Test &test)
 	test.do_test();
 }
 
-void
+int
 Unit_test::_last_line(void)
 {
 	int success;
@@ -30,6 +30,8 @@ Unit_test::_last_line(void)
 	std::cout << "/";
 	std::cout << _test.size();
 	std::cout << " tests checked\n";
+
+	return static_cast<bool>(success - _test.size());
 }
 
 int
@@ -44,6 +46,5 @@ Unit_test::launch_tests(void)
 		std::cout << unit_name << " : " << it->_name << " : ";
 		it++->_result.print_result();
 	}
-	_last_line();
-	return (0);
+	return _last_line();
 }


### PR DESCRIPTION
### framework: fix return value

`Unit_test::launch_tests(void)` return a consistency value

### framework: add libraries for GNU/Linux compilation

`MacOS` doesn't notify that libraries are missing. So I noticed this under `GNU/Linux`.