### PR TITLE
Makefile: miscellaneous changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ db: $(NAME)
 
 format:
 	@printf "$(YELLOW)Formating the sources..$(DEFAULT)\n"
-	@clang-format -i $(SRCS) $(INCS)
+	@clang-format -i $(shell find . -name "*.hpp" -or -name "*.cpp")
 
 doc:
 	@printf "$(YELLOW)Generating documentations..$(DEFAULT)\n"

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ $(LIB): $(OBJS)
 	@printf "$(YELLOW)Creating $(LIB)..$(DEFAULT)\n"
 	@$(AR) $(LIB) $(OBJS)
 	@printf "$(GREEN)---> $(LIB) is ready$(DEFAULT)\n"
+	@printf "$(YELLOW)make re test..$(DEFAULT)\n"
+	@$(MAKE) --directory=test re
+	@printf "$(GREEN)---> test$(DEFAULT)\n"
 
 test: $(LIB)
 	@$(MAKE) --directory=test

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,6 @@ SRCS	+=	$(SRCD)/arguments/check_argc_number.cpp
 
 INCD	=	inc
 
-INCS	+=	$(INCD)/arguments.hpp
-
 
 #	Objets
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,9 @@ $(OBJD)/%.o: $(SRCD)/%.cpp
 	@$(CXX) -c $(<) $(CFLAGS) -I$(INCD) -o $(@)
 
 $(LIB): $(OBJS)
+	@printf "$(YELLOW)Creating $(LIB)..$(DEFAULT)\n"
 	@$(AR) $(LIB) $(OBJS)
+	@printf "$(GREEN)---> $(LIB) is ready$(DEFAULT)\n"
 
 test: $(LIB)
 	@$(MAKE) --directory=test

--- a/test/Makefile
+++ b/test/Makefile
@@ -58,7 +58,7 @@ db: $(NAME)
 
 format:
 	@printf "$(YELLOW)Formating the sources..$(DEFAULT)\n"
-	@clang-format -i $(SRCS) $(INCS)
+	@clang-format -i $(shell find . -name "*.hpp" -or -name "*.cpp")
 
 clean:
 	@$(RM) $(OBJD)

--- a/test/framework/Makefile
+++ b/test/framework/Makefile
@@ -52,7 +52,7 @@ $(OBJD)/%.o: $(SRCD)/%.cpp
 
 format:
 	@printf "$(YELLOW)Formating the sources..$(DEFAULT)\n"
-	@clang-format -i $(SRCS) $(INCS)
+	@clang-format -i $(shell find . -name "*.hpp" -or -name "*.cpp")
 
 clean:
 	@$(RM) $(OBJD)


### PR DESCRIPTION
# Makefile: miscellaneous changes

### `make $(LIB)`: recompile test when libwebserv.a is updated

When you update a source file for `webserv`, and then you `make test`
the `test` program isn't notice by the update.
That why we should recompile the test. Else, we aren't testing the update we wrote.

### `make $(LIB)`: print a message

Just print this message during the `libwebserv.a` compilation:

```
Creating libwebserv.a..
---> libwebserv.a is ready
```

### Update clang-format

```diff
- @clang-format -i $(SRCS) $(INCS)
+ @clang-format -i $(shell find . -name "*.hpp" -or -name "*.cpp")
```

That formats each file of each subfolder instead of each file listed in the Makefile.