### PR TITLE
Makefile: create formatdocker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,10 @@ format:
 	@printf "$(YELLOW)Formating the sources..$(DEFAULT)\n"
 	@clang-format -i $(shell find . -name "*.hpp" -or -name "*.cpp" -or -name "*.js")
 
+formatdocker:
+	@printf "$(YELLOW)launch tgrivel/clang-format docker image..$(DEFAULT)\n"
+	@docker run --rm -v $(shell pwd):/documents tgrivel/clang-format -i $(shell find . -name "*.hpp" -or -name "*.cpp" -or -name "*.js")
+
 doc:
 	@printf "$(YELLOW)Generating documentations..$(DEFAULT)\n"
 	@$(ADOC) $(DOCU) -o $(INDEX)


### PR DESCRIPTION
# formatdocker

Format the sources files with clang-format running in a docker image.
I push [tgrivel/clang-format](https://hub.docker.com/r/tgrivel/clang-format) on docker hub plateform to have an available formater.

## Check this PR

1. checkout on `formatdocker`
2. unformat a source file
3. execute `make formatdocker`
4. check if the source file was reformated
