### PR TITLE
Query parser

### DIFF
--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -38,6 +38,7 @@ class Request
 	void parse_other_lines(std::vector<std::string> tmp_vector);
 	void clean_content_type();
 	void check_if_has_query(std::string &path);
+	void clean_path(std::string &path);
 };
 
 std::ostream &operator<<(std::ostream &, Request const &);

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -37,9 +37,9 @@ class Request
 	void parse_first_line(std::string firstLine);
 	void parse_other_lines(std::vector<std::string> tmp_vector);
 	void clean_content_type();
-	void check_if_has_query(std::string &path);
-	void clean_path(std::string &path);
-	void empty_path_handler(std::string &path);
+	void check_if_has_query();
+	void clean_path();
+	void empty_path_handler();
 };
 
 std::ostream &operator<<(std::ostream &, Request const &);

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -39,6 +39,7 @@ class Request
 	void clean_content_type();
 	void check_if_has_query(std::string &path);
 	void clean_path(std::string &path);
+	void empty_path_handler(std::string &path);
 };
 
 std::ostream &operator<<(std::ostream &, Request const &);

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -20,21 +20,24 @@ class Request
 
 	void parse_buffer(std::string);
 	bool method_is_authorized(std::string method) const;
-	// Getters
+
 	std::string		get_method() const;
 	std::string		get_path() const;
 	std::string		get_protocol() const;
 	std::string		get_host() const;
 	bool			get_file_exist() const;
+	bool			get_has_query() const;
+	void			set_query_false();
 	const t_object &get_map() const;
-	t_object		_request_map;
 	std::string		trim(const std::string &s);
+	t_object		_request_map;
 
   private:
+	bool _has_query;
 	void parse_first_line(std::string firstLine);
 	void parse_other_lines(std::vector<std::string> tmp_vector);
 	void clean_content_type();
-	bool _has_query;
+	void check_if_has_query(std::string &path);
 };
 
 std::ostream &operator<<(std::ostream &, Request const &);

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -34,6 +34,7 @@ class Request
 	void parse_first_line(std::string firstLine);
 	void parse_other_lines(std::vector<std::string> tmp_vector);
 	void clean_content_type();
+	bool _has_query;
 };
 
 std::ostream &operator<<(std::ostream &, Request const &);

--- a/src/Socket/Socket.cpp
+++ b/src/Socket/Socket.cpp
@@ -218,6 +218,7 @@ Socket::clean_request()
 	_header_str = "";
 	_body_str = "";
 	_request._request_map.clear();
+	_request.set_query_false();
 }
 
 void

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -3,7 +3,7 @@
 namespace http
 {
 
-Request::Request(): _has_query(false){}
+Request::Request() : _has_query(false) {}
 Request::~Request() {}
 
 void
@@ -47,6 +47,7 @@ Request::parse_first_line(std::string firstLine)
 	_request_map["Method"] = tmp_vector[0];
 	_request_map["Path"] = tmp_vector[1];
 	_request_map["Protocol"] = tmp_vector[2];
+	check_if_has_query(_request_map["Path"]);
 }
 
 void
@@ -150,6 +151,31 @@ Request::clean_content_type()
 			= _request_map["Content-Type"].substr(_request_map["Content-Type"].find("boundary=") + 9);
 	}
 	_request_map["Content-Type"] = _request_map["Content-Type"].substr(0, end_of_first_part);
+}
+
+void
+Request::check_if_has_query(std::string &path)
+{
+	// check if path = '/' first in another function
+	size_t		last_slash = path.find_last_of('/');
+	std::string last_part = path.substr(last_slash + 1);
+	size_t		question_mark = last_part.find_first_of('?');
+	if (question_mark == std::string::npos)
+		return;
+	_has_query = true;
+	_request_map["Query"] = last_part.substr(question_mark + 1);
+}
+
+bool
+Request::get_has_query() const
+{
+	return _has_query;
+}
+
+void
+Request::set_query_false()
+{
+	_has_query = false;
 }
 
 } /* namespace http */

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -184,7 +184,7 @@ void
 Request::clean_path()
 {
 	size_t question_mark = _request_map["Path"].find_first_of('?');
-	_request_map["Path"] = _request_map["Path"].substr(0, question_mark - 1);
+	_request_map["Path"] = _request_map["Path"].substr(0, question_mark);
 }
 
 void

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -3,7 +3,7 @@
 namespace http
 {
 
-Request::Request() {}
+Request::Request(): _has_query(false){}
 Request::~Request() {}
 
 void

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -47,6 +47,7 @@ Request::parse_first_line(std::string firstLine)
 	_request_map["Method"] = tmp_vector[0];
 	_request_map["Path"] = tmp_vector[1];
 	_request_map["Protocol"] = tmp_vector[2];
+	empty_path_handler(_request_map["Path"]);
 	check_if_has_query(_request_map["Path"]);
 	if (_has_query)
 		clean_path(_request_map["Path"]);
@@ -185,6 +186,16 @@ Request::clean_path(std::string &path)
 {
 	size_t question_mark = path.find_first_of('?');
 	_request_map["Path"] = path.substr(0, question_mark - 1);
+}
+
+void
+Request::empty_path_handler(std::string &path)
+{
+	std::cout << "PATH: " << path << std::endl;
+	if (path.size() == 1 && path[0] == '/')
+	{
+		_request_map["Path"] = "/index.html";
+	}
 }
 
 } /* namespace http */

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -191,7 +191,6 @@ Request::clean_path(std::string &path)
 void
 Request::empty_path_handler(std::string &path)
 {
-	std::cout << "PATH: " << path << std::endl;
 	if (path.size() == 1 && path[0] == '/')
 	{
 		_request_map["Path"] = "/index.html";

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -48,6 +48,8 @@ Request::parse_first_line(std::string firstLine)
 	_request_map["Path"] = tmp_vector[1];
 	_request_map["Protocol"] = tmp_vector[2];
 	check_if_has_query(_request_map["Path"]);
+	if (_has_query)
+		clean_path(_request_map["Path"]);
 }
 
 void
@@ -176,6 +178,13 @@ void
 Request::set_query_false()
 {
 	_has_query = false;
+}
+
+void
+Request::clean_path(std::string &path)
+{
+	size_t question_mark = path.find_first_of('?');
+	_request_map["Path"] = path.substr(0, question_mark - 1);
 }
 
 } /* namespace http */

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -47,10 +47,10 @@ Request::parse_first_line(std::string firstLine)
 	_request_map["Method"] = tmp_vector[0];
 	_request_map["Path"] = tmp_vector[1];
 	_request_map["Protocol"] = tmp_vector[2];
-	empty_path_handler(_request_map["Path"]);
-	check_if_has_query(_request_map["Path"]);
+	empty_path_handler();
+	check_if_has_query();
 	if (_has_query)
-		clean_path(_request_map["Path"]);
+		clean_path();
 }
 
 void
@@ -157,11 +157,10 @@ Request::clean_content_type()
 }
 
 void
-Request::check_if_has_query(std::string &path)
+Request::check_if_has_query()
 {
-	// check if path = '/' first in another function
-	size_t		last_slash = path.find_last_of('/');
-	std::string last_part = path.substr(last_slash + 1);
+	size_t		last_slash = _request_map["Path"].find_last_of('/');
+	std::string last_part = _request_map["Path"].substr(last_slash + 1);
 	size_t		question_mark = last_part.find_first_of('?');
 	if (question_mark == std::string::npos)
 		return;
@@ -182,16 +181,16 @@ Request::set_query_false()
 }
 
 void
-Request::clean_path(std::string &path)
+Request::clean_path()
 {
-	size_t question_mark = path.find_first_of('?');
-	_request_map["Path"] = path.substr(0, question_mark - 1);
+	size_t question_mark = _request_map["Path"].find_first_of('?');
+	_request_map["Path"] = _request_map["Path"].substr(0, question_mark - 1);
 }
 
 void
-Request::empty_path_handler(std::string &path)
+Request::empty_path_handler()
 {
-	if (path.size() == 1 && path[0] == '/')
+	if (_request_map["Path"].size() == 1 && _request_map["Path"][0] == '/')
 	{
 		_request_map["Path"] = "/index.html";
 	}


### PR DESCRIPTION
This feature adds some functions to Request class.
To check if a query is present in the URI, separate it from the rest
and place it in _request_map["Query'] key.
Request has a new attribute _has_query with a getter and setter (setter only to put it back to false).
This branch also add empty_path_handler() that checks if the path is only '/' and replaces it with '/index.html'. 