### PR TITLE
Header error checks

### DIFF
--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -21,7 +21,6 @@ class Request
 	int				parse_buffer(std::string);
 	bool			method_is_authorized(std::string method) const;
 	int				error_code;
-	unsigned long 	max_content_length;
 	std::string		get_method() const;
 	std::string		get_path() const;
 	std::string		get_protocol() const;
@@ -35,6 +34,7 @@ class Request
 	t_object		_request_map;
 
   private:
+	unsigned long 	_max_content_length;
 	bool _has_query;
 	int	 parse_first_line(std::string firstLine);
 	void parse_other_lines(std::vector<std::string> tmp_vector);

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -18,9 +18,9 @@ class Request
 	Request();
 	~Request();
 
-	void parse_buffer(std::string);
-	bool method_is_authorized(std::string method) const;
-
+	int				parse_buffer(std::string);
+	bool			method_is_authorized(std::string method) const;
+	int				error_code;
 	std::string		get_method() const;
 	std::string		get_path() const;
 	std::string		get_protocol() const;
@@ -34,7 +34,7 @@ class Request
 
   private:
 	bool _has_query;
-	void parse_first_line(std::string firstLine);
+	int	 parse_first_line(std::string firstLine);
 	void parse_other_lines(std::vector<std::string> tmp_vector);
 	void clean_content_type();
 	void check_if_has_query();

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -40,6 +40,7 @@ class Request
 	void check_if_has_query();
 	void clean_path();
 	void empty_path_handler();
+	int check_header();
 };
 
 std::ostream &operator<<(std::ostream &, Request const &);

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -27,7 +27,6 @@ class Request
 	bool			get_file_exist() const;
 	bool			get_has_query() const;
 	void			set_query_false();
-	void			set_max_content_length(unsigned long);
 	const t_object &get_map() const;
 	int				get_error_code() const;
 	void			set_error_code(int);
@@ -35,16 +34,15 @@ class Request
 	t_object		_request_map;
 
   private:
-	int			  _error_code;
-	unsigned long _max_content_length;
-	bool		  _has_query;
-	void		  parse_first_line(std::string firstLine);
-	void		  parse_other_lines(std::vector<std::string> tmp_vector);
-	void		  clean_content_type();
-	void		  check_if_has_query();
-	void		  clean_path();
-	void		  empty_path_handler();
-	int			  check_header();
+	int	 _error_code;
+	bool _has_query;
+	void parse_first_line(std::string firstLine);
+	void parse_other_lines(std::vector<std::string> tmp_vector);
+	void clean_content_type();
+	void check_if_has_query();
+	void clean_path();
+	void empty_path_handler();
+	void check_header();
 };
 
 std::ostream &operator<<(std::ostream &, Request const &);

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -18,9 +18,8 @@ class Request
 	Request();
 	~Request();
 
-	void				parse_buffer(std::string);
+	void			parse_buffer(std::string);
 	bool			method_is_authorized(std::string method) const;
-	int				error_code;
 	std::string		get_method() const;
 	std::string		get_path() const;
 	std::string		get_protocol() const;
@@ -30,13 +29,16 @@ class Request
 	void			set_query_false();
 	void			set_max_content_length(unsigned long);
 	const t_object &get_map() const;
+	int				get_error_code() const;
+	void			set_error_code(int);
 	std::string		trim(const std::string &s);
 	t_object		_request_map;
 
   private:
+	int			  _error_code;
 	unsigned long _max_content_length;
 	bool		  _has_query;
-	int			  parse_first_line(std::string firstLine);
+	void		  parse_first_line(std::string firstLine);
 	void		  parse_other_lines(std::vector<std::string> tmp_vector);
 	void		  clean_content_type();
 	void		  check_if_has_query();

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -34,15 +34,15 @@ class Request
 	t_object		_request_map;
 
   private:
-	unsigned long 	_max_content_length;
-	bool _has_query;
-	int	 parse_first_line(std::string firstLine);
-	void parse_other_lines(std::vector<std::string> tmp_vector);
-	void clean_content_type();
-	void check_if_has_query();
-	void clean_path();
-	void empty_path_handler();
-	int	 check_header();
+	unsigned long _max_content_length;
+	bool		  _has_query;
+	int			  parse_first_line(std::string firstLine);
+	void		  parse_other_lines(std::vector<std::string> tmp_vector);
+	void		  clean_content_type();
+	void		  check_if_has_query();
+	void		  clean_path();
+	void		  empty_path_handler();
+	int			  check_header();
 };
 
 std::ostream &operator<<(std::ostream &, Request const &);

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -21,6 +21,7 @@ class Request
 	int				parse_buffer(std::string);
 	bool			method_is_authorized(std::string method) const;
 	int				error_code;
+	unsigned long 	max_content_length;
 	std::string		get_method() const;
 	std::string		get_path() const;
 	std::string		get_protocol() const;
@@ -28,6 +29,7 @@ class Request
 	bool			get_file_exist() const;
 	bool			get_has_query() const;
 	void			set_query_false();
+	void			set_max_content_length(unsigned long);
 	const t_object &get_map() const;
 	std::string		trim(const std::string &s);
 	t_object		_request_map;
@@ -40,7 +42,7 @@ class Request
 	void check_if_has_query();
 	void clean_path();
 	void empty_path_handler();
-	int check_header();
+	int	 check_header();
 };
 
 std::ostream &operator<<(std::ostream &, Request const &);

--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -18,7 +18,7 @@ class Request
 	Request();
 	~Request();
 
-	int				parse_buffer(std::string);
+	void				parse_buffer(std::string);
 	bool			method_is_authorized(std::string method) const;
 	int				error_code;
 	std::string		get_method() const;

--- a/inc/Response.hpp
+++ b/inc/Response.hpp
@@ -21,6 +21,7 @@ class Response
 
 	Response();
 	~Response(void);
+	std::string		server_name;
 	std::string		get_http_response(void);
 	void			load_http_request(Request &req);
 	const t_object &get_map() const;

--- a/inc/Socket.hpp
+++ b/inc/Socket.hpp
@@ -29,6 +29,7 @@ class Socket
 	int				   _connection_fd;
 	int				   _sock_id;
 	int				   _connection;
+	unsigned long	   _max_content_length;
 	struct sockaddr_in _address;
 	void			   create_socket(int domain, int type, int protocol);
 	void			   binding_socket();
@@ -43,6 +44,7 @@ class Socket
 	void			   create_new_file();
 	std::string		   clean_end_of_file(std::string const &str_to_clean);
 	const std::string &get_dir_path() const;
+	void			   check_content_lenght_authorized() const;
 
   public:
 	Socket(int domain, unsigned short port, int type, int protocol, std::string path,

--- a/inc/Socket.hpp
+++ b/inc/Socket.hpp
@@ -44,7 +44,7 @@ class Socket
 	void			   create_new_file();
 	std::string		   clean_end_of_file(std::string const &str_to_clean);
 	const std::string &get_dir_path() const;
-	void			   check_content_lenght_authorized() const;
+	void			   check_content_lenght_authorized();
 
   public:
 	Socket(int domain, unsigned short port, int type, int protocol, std::string path,

--- a/inc/Socket.hpp
+++ b/inc/Socket.hpp
@@ -48,7 +48,7 @@ class Socket
 
   public:
 	Socket(int domain, unsigned short port, int type, int protocol, std::string path,
-		   unsigned long max_length);
+		   unsigned long max_length = ULONG_MAX);
 	int	 socket_recv();
 	void socket_accept();
 	int	 get_sock_id() const;

--- a/inc/Socket.hpp
+++ b/inc/Socket.hpp
@@ -45,7 +45,7 @@ class Socket
 	const std::string &get_dir_path() const;
 
   public:
-	Socket(int domain, unsigned short port, int type, int protocol, std::string path);
+	Socket(int domain, unsigned short port, int type, int protocol, std::string path, unsigned long max_length);
 	int	 socket_recv();
 	void socket_accept();
 	int	 get_sock_id() const;

--- a/inc/Socket.hpp
+++ b/inc/Socket.hpp
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <climits>
 
 #define LISTEN_BACKLOG 10
 #define MAXLINE 4096

--- a/inc/Socket.hpp
+++ b/inc/Socket.hpp
@@ -3,6 +3,7 @@
 
 #include "Request.hpp"
 #include "Response.hpp"
+#include <climits>
 #include <cstring>
 #include <errno.h>
 #include <fcntl.h>
@@ -12,7 +13,6 @@
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <unistd.h>
-#include <climits>
 
 #define LISTEN_BACKLOG 10
 #define MAXLINE 4096
@@ -53,6 +53,7 @@ class Socket
 	int	 socket_recv();
 	void socket_accept();
 	int	 get_sock_id() const;
+	void set_server_name(std::string);
 };
 
 #endif

--- a/inc/Socket.hpp
+++ b/inc/Socket.hpp
@@ -45,7 +45,8 @@ class Socket
 	const std::string &get_dir_path() const;
 
   public:
-	Socket(int domain, unsigned short port, int type, int protocol, std::string path, unsigned long max_length);
+	Socket(int domain, unsigned short port, int type, int protocol, std::string path,
+		   unsigned long max_length);
 	int	 socket_recv();
 	void socket_accept();
 	int	 get_sock_id() const;

--- a/inc/Socket.hpp
+++ b/inc/Socket.hpp
@@ -53,7 +53,7 @@ class Socket
 	int	 socket_recv();
 	void socket_accept();
 	int	 get_sock_id() const;
-	void set_server_name(std::string);
+	void set_server_name(const std::string &);
 };
 
 #endif

--- a/src/Socket/Socket.cpp
+++ b/src/Socket/Socket.cpp
@@ -95,15 +95,15 @@ Socket::socket_recv()
 		if (LOG_SOCKET)
 			std::cout << "body str:" << _body_str << std::endl;
 	}
-	_request.parse_buffer(_header_str);
-	if (_request._request_map["Content-Type"].compare("multipart/form-data") == 0)
+	int ret = _request.parse_buffer(_header_str);
+	if (ret == 0 && _request._request_map["Content-Type"].compare("multipart/form-data") == 0)
 	{
 		if (LOG_SOCKET)
 			std::cout << "Content-type = multipart/form-data" << std::endl;
 		multipart_handler();
 		std::memset(buffer, 0, MAXLINE);
 	}
-	if (_request.get_method().compare("DELETE") == 0)
+	if (ret == 0 && _request.get_method().compare("DELETE") == 0)
 	{
 		delete_handler();
 	}

--- a/src/Socket/Socket.cpp
+++ b/src/Socket/Socket.cpp
@@ -96,15 +96,15 @@ Socket::socket_recv()
 		if (LOG_SOCKET)
 			std::cout << "body str:" << _body_str << std::endl;
 	}
-	int ret = _request.parse_buffer(_header_str);
-	if (ret == 0 && _request._request_map["Content-Type"].compare("multipart/form-data") == 0)
+	_request.parse_buffer(_header_str);
+	if (_request._request_map["Content-Type"].compare("multipart/form-data") == 0)
 	{
 		if (LOG_SOCKET)
 			std::cout << "Content-type = multipart/form-data" << std::endl;
 		multipart_handler();
 		std::memset(buffer, 0, MAXLINE);
 	}
-	if (ret == 0 && _request.get_method().compare("DELETE") == 0)
+	if (_request.get_method().compare("DELETE") == 0)
 	{
 		delete_handler();
 	}

--- a/src/Socket/Socket.cpp
+++ b/src/Socket/Socket.cpp
@@ -1,15 +1,15 @@
 #include "Socket.hpp"
 
-Socket::Socket(int domain, unsigned short port, int type, int protocol, std::string path)
+Socket::Socket(int domain, unsigned short port, int type, int protocol, std::string path, unsigned long max_length)
 {
 	_address.sin_family = domain;
 	_address.sin_port = htons(port);
 	_address.sin_addr.s_addr = htonl(INADDR_ANY);
-
 	create_socket(domain, type, protocol);
 	set_socket_non_blocking();
 	binding_socket();
 	start_listening();
+	_request.set_max_content_length(max_length);
 	_header_str = "";
 	_body_str = "";
 	_dir_path = path;

--- a/src/Socket/Socket.cpp
+++ b/src/Socket/Socket.cpp
@@ -143,10 +143,10 @@ Socket::delete_handler()
 	std::string fullpath = _dir_path + "/uploads" + file_name;
 	if (access(fullpath.c_str(), F_OK) != -1)
 	{
-		_request._request_map["FileName"] = "exist";
+		_request._request_map["fileStatus"] = "exist";
 		int ret = remove(fullpath.c_str());
 		if (ret != 0)
-			_request._request_map["FileName"] = "r_fail";
+			_request._request_map["fileStatus"] = "r_fail";
 	}
 }
 
@@ -196,7 +196,7 @@ Socket::create_new_file()
 	}
 	else
 	{
-		_request._request_map["FileName"] = "exist";
+		_request._request_map["fileStatus"] = "exist";
 	}
 }
 
@@ -247,7 +247,7 @@ Socket::check_content_lenght_authorized()
 		char *end = NULL;
 		if (_max_content_length < std::strtoul(req_map["Content-Length"].c_str(), &end, 10))
 		{
-			this->_request.set_error_code(406);
+			this->_request.set_error_code(413);
 		}
 	}
 }

--- a/src/Socket/Socket.cpp
+++ b/src/Socket/Socket.cpp
@@ -219,6 +219,7 @@ Socket::clean_request()
 	_body_str = "";
 	_request._request_map.clear();
 	_request.set_query_false();
+	_request.error_code = 0;
 }
 
 void

--- a/src/Socket/Socket.cpp
+++ b/src/Socket/Socket.cpp
@@ -253,7 +253,7 @@ Socket::check_content_lenght_authorized()
 }
 
 void
-Socket::set_server_name(std::string new_name)
+Socket::set_server_name(const std::string &new_name)
 {
 	_response.server_name = new_name;
 }

--- a/src/Socket/Socket.cpp
+++ b/src/Socket/Socket.cpp
@@ -1,6 +1,7 @@
 #include "Socket.hpp"
 
-Socket::Socket(int domain, unsigned short port, int type, int protocol, std::string path, unsigned long max_length)
+Socket::Socket(int domain, unsigned short port, int type, int protocol, std::string path,
+			   unsigned long max_length)
 {
 	_address.sin_family = domain;
 	_address.sin_port = htons(port);
@@ -227,6 +228,8 @@ Socket::send_response()
 {
 	int			send_ret = 0;
 	std::string full_response_str(this->_response.get_http_response());
+	std::cout << "is send :" << std::endl;
+	std::cout << full_response_str << std::endl;
 	send_ret = send(_connection_fd, full_response_str.c_str(), full_response_str.length(), 0);
 	if (send_ret < static_cast<int>(full_response_str.length()))
 	{

--- a/src/Socket/Socket.cpp
+++ b/src/Socket/Socket.cpp
@@ -251,3 +251,9 @@ Socket::check_content_lenght_authorized()
 		}
 	}
 }
+
+void
+Socket::set_server_name(std::string new_name)
+{
+	_response.server_name = new_name;
+}

--- a/src/Socket/Socket.cpp
+++ b/src/Socket/Socket.cpp
@@ -10,7 +10,7 @@ Socket::Socket(int domain, unsigned short port, int type, int protocol, std::str
 	set_socket_non_blocking();
 	binding_socket();
 	start_listening();
-	_request.set_max_content_length(max_length);
+	_max_content_length = max_length;
 	_header_str = "";
 	_body_str = "";
 	_dir_path = path;
@@ -130,6 +130,7 @@ Socket::multipart_handler()
 	}
 	if (LOG_SOCKET)
 		std::cout << "_body_str.size(): " << _body_str.size() << std::endl;
+	check_content_lenght_authorized();
 	create_new_file();
 }
 
@@ -236,4 +237,9 @@ Socket::send_response()
 		send_ret = send(_connection_fd, full_response_str.c_str(), full_response_str.length(), 0);
 	}
 	close(_connection_fd);
+}
+
+void
+Socket::check_content_lenght_authorized() const
+{
 }

--- a/src/Socket/Socket.cpp
+++ b/src/Socket/Socket.cpp
@@ -220,7 +220,7 @@ Socket::clean_request()
 	_body_str = "";
 	_request._request_map.clear();
 	_request.set_query_false();
-	_request.error_code = 0;
+	_request.set_error_code(0);
 }
 
 void

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -6,7 +6,7 @@ namespace http
 Request::Request() : error_code(0), _has_query(false) {}
 Request::~Request() {}
 
-int
+void
 Request::parse_buffer(std::string str_buff)
 {
 	std::vector<std::string> tmp_vector;
@@ -22,17 +22,9 @@ Request::parse_buffer(std::string str_buff)
 	}
 	int ret = this->parse_first_line(tmp_vector[0]);
 	if (ret == 1)
-	{
 		error_code = 400;
-		return 1;
-	}
 	this->parse_other_lines(tmp_vector);
 	ret = check_header();
-	if (ret == 1)
-	{
-		return 1;
-	}
-	return 0;
 }
 
 int

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -27,6 +27,7 @@ Request::parse_buffer(std::string str_buff)
 		return 1;
 	}
 	this->parse_other_lines(tmp_vector);
+	int check_header();
 	if (_request_map.find("Content-Type") != _request_map.end())
 		this->clean_content_type();
 	return 0;
@@ -201,6 +202,12 @@ Request::empty_path_handler()
 	{
 		_request_map["Path"] = "/index.html";
 	}
+}
+
+int Request::check_header()
+{
+
+	return 0;
 }
 
 } /* namespace http */

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -203,17 +203,6 @@ Request::check_header()
 	check_if_has_query();
 	if (_has_query)
 		clean_path();
-	// if (_request_map.find("Content-Length") != _request_map.end())
-	// {
-	// 	std::cout << "CONTENT_LENGTH: " << _request_map["Content-Length"] << std::endl;
-	// 	std::cout << "CONTENT_LENGTH_MAX " << _max_content_length << std::endl;
-	// 	char *end = NULL;
-	// 	if (_max_content_length < std::strtoul(_request_map["Content-Length"].c_str(), &end, 10))
-	// 	{
-	// 		set_error_code(406);
-	// 		return 1;
-	// 	}
-	// }
 }
 
 int

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -116,7 +116,7 @@ Request::get_host() const
 bool
 Request::get_file_exist() const
 {
-	return (_request_map.find("FileName") != _request_map.end());
+	return (_request_map.find("fileStatus") != _request_map.end());
 }
 
 bool

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -195,7 +195,7 @@ Request::empty_path_handler()
 	}
 }
 
-int
+void
 Request::check_header()
 {
 	if (_request_map.find("Content-Type") != _request_map.end())
@@ -203,24 +203,17 @@ Request::check_header()
 	check_if_has_query();
 	if (_has_query)
 		clean_path();
-	if (_request_map.find("Content-Length") != _request_map.end())
-	{
-		std::cout << "CONTENT_LENGTH: " << _request_map["Content-Length"] << std::endl;
-		std::cout << "CONTENT_LENGTH_MAX " << _max_content_length << std::endl;
-		char *end = NULL;
-		if (_max_content_length < std::strtoul(_request_map["Content-Length"].c_str(), &end, 10))
-		{
-			set_error_code(406);
-			return 1;
-		}
-	}
-	return 0;
-}
-
-void
-Request::set_max_content_length(unsigned long max_length)
-{
-	_max_content_length = max_length;
+	// if (_request_map.find("Content-Length") != _request_map.end())
+	// {
+	// 	std::cout << "CONTENT_LENGTH: " << _request_map["Content-Length"] << std::endl;
+	// 	std::cout << "CONTENT_LENGTH_MAX " << _max_content_length << std::endl;
+	// 	char *end = NULL;
+	// 	if (_max_content_length < std::strtoul(_request_map["Content-Length"].c_str(), &end, 10))
+	// 	{
+	// 		set_error_code(406);
+	// 		return 1;
+	// 	}
+	// }
 }
 
 int

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -27,9 +27,7 @@ Request::parse_buffer(std::string str_buff)
 		return 1;
 	}
 	this->parse_other_lines(tmp_vector);
-	int check_header();
-	if (_request_map.find("Content-Type") != _request_map.end())
-		this->clean_content_type();
+	check_header();
 	return 0;
 }
 
@@ -55,9 +53,6 @@ Request::parse_first_line(std::string firstLine)
 	_request_map["Path"] = tmp_vector[1];
 	_request_map["Protocol"] = tmp_vector[2];
 	empty_path_handler();
-	check_if_has_query();
-	if (_has_query)
-		clean_path();
 	return 0;
 }
 
@@ -204,10 +199,21 @@ Request::empty_path_handler()
 	}
 }
 
-int Request::check_header()
+int
+Request::check_header()
 {
+	if (_request_map.find("Content-Type") != _request_map.end())
+		this->clean_content_type();
+	check_if_has_query();
+	if (_has_query)
+		clean_path();
 
 	return 0;
+}
+
+void			Request::set_max_content_length(unsigned long max_length)
+{
+	max_content_length = max_length;
 }
 
 } /* namespace http */

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -213,7 +213,7 @@ Request::check_header()
 
 void			Request::set_max_content_length(unsigned long max_length)
 {
-	max_content_length = max_length;
+	_max_content_length = max_length;
 }
 
 } /* namespace http */

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -27,7 +27,11 @@ Request::parse_buffer(std::string str_buff)
 		return 1;
 	}
 	this->parse_other_lines(tmp_vector);
-	check_header();
+	ret = check_header();
+	if (ret == 1)
+	{
+		return 1;
+	}
 	return 0;
 }
 
@@ -207,11 +211,22 @@ Request::check_header()
 	check_if_has_query();
 	if (_has_query)
 		clean_path();
-
+	if (_request_map.find("Content-Length") != _request_map.end())
+	{
+		std::cout << "CONTENT_LENGTH: " << _request_map["Content-Length"] << std::endl;
+		std::cout << "CONTENT_LENGTH_MAX " << _max_content_length << std::endl;
+		char *end = NULL;
+		if (_max_content_length < std::strtoul(_request_map["Content-Length"].c_str(), &end, 10))
+		{
+			error_code = 406;
+			return 1;
+		}
+	}
 	return 0;
 }
 
-void			Request::set_max_content_length(unsigned long max_length)
+void
+Request::set_max_content_length(unsigned long max_length)
 {
 	_max_content_length = max_length;
 }

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -12,9 +12,9 @@ Response::~Response(void) {}
 void
 Response::load_http_request(Request &request)
 {
-	if (request.error_code != 0)
+	if (request.get_error_code() != 0)
 	{
-		load_response_post_delete(request.error_code);
+		load_response_post_delete(request.get_error_code());
 	}
 	init_response_map();
 	std::string path = _dir_path;

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -15,51 +15,47 @@ Response::load_http_request(Request &request)
 	if (request.get_error_code() != 0)
 	{
 		load_response_post_delete(request.get_error_code());
+		request.set_error_code(0);
+		return;
 	}
-	init_response_map();
-	std::string path = _dir_path;
-	path += request.get_path();
 	if (has_php_extension(request))
 	{
 		php_handler(request);
 		return;
 	}
+	init_response_map();
+	std::string path = _dir_path;
+	path += request.get_path();
 	if (request.get_method().compare("GET") == 0)
 	{
-		init_response_map();
-		std::string path = _dir_path;
-		path += request.get_path();
-		if (request.get_method().compare("GET") == 0)
+		if (access(path.c_str(), F_OK))
 		{
-			if (access(path.c_str(), F_OK))
-			{
-				load_response_get(404, path);
-			}
-			else
-			{
-				load_response_get(200, path);
-			}
-		}
-		else if (request.get_method().compare("POST") == 0)
-		{
-			if (request._request_map["FileName"].compare("exist") == 0)
-				load_response_post_delete(409);
-			else
-				load_response_post_delete(201);
-		}
-		else if (request.get_method().compare("DELETE") == 0)
-		{
-			if (request._request_map["FileName"].compare("exist") == 0)
-				load_response_post_delete(204);
-			else if (request._request_map["FileName"].compare("r_fail") == 0)
-				load_response_post_delete(500);
-			else
-				load_response_post_delete(404);
+			load_response_get(404, path);
 		}
 		else
 		{
-			load_response_get(405, path);
+			load_response_get(200, path);
 		}
+	}
+	else if (request.get_method().compare("POST") == 0)
+	{
+		if (request._request_map["FileName"].compare("exist") == 0)
+			load_response_post_delete(409);
+		else
+			load_response_post_delete(201);
+	}
+	else if (request.get_method().compare("DELETE") == 0)
+	{
+		if (request._request_map["FileName"].compare("exist") == 0)
+			load_response_post_delete(204);
+		else if (request._request_map["FileName"].compare("r_fail") == 0)
+			load_response_post_delete(500);
+		else
+			load_response_post_delete(404);
+	}
+	else
+	{
+		load_response_get(405, path);
 	}
 }
 

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -26,34 +26,40 @@ Response::load_http_request(Request &request)
 	}
 	if (request.get_method().compare("GET") == 0)
 	{
-		if (access(path.c_str(), F_OK))
+		init_response_map();
+		std::string path = _dir_path;
+		path += request.get_path();
+		if (request.get_method().compare("GET") == 0)
 		{
-			load_response_get(404, path);
+			if (access(path.c_str(), F_OK))
+			{
+				load_response_get(404, path);
+			}
+			else
+			{
+				load_response_get(200, path);
+			}
+		}
+		else if (request.get_method().compare("POST") == 0)
+		{
+			if (request._request_map["FileName"].compare("exist") == 0)
+				load_response_post_delete(409);
+			else
+				load_response_post_delete(201);
+		}
+		else if (request.get_method().compare("DELETE") == 0)
+		{
+			if (request._request_map["FileName"].compare("exist") == 0)
+				load_response_post_delete(204);
+			else if (request._request_map["FileName"].compare("r_fail") == 0)
+				load_response_post_delete(500);
+			else
+				load_response_post_delete(404);
 		}
 		else
 		{
-			load_response_get(200, path);
+			load_response_get(405, path);
 		}
-	}
-	else if (request.get_method().compare("POST") == 0)
-	{
-		if (request._request_map["FileName"].compare("exist") == 0)
-			load_response_post_delete(409);
-		else
-			load_response_post_delete(201);
-	}
-	else if (request.get_method().compare("DELETE") == 0)
-	{
-		if (request._request_map["FileName"].compare("exist") == 0)
-			load_response_post_delete(204);
-		else if (request._request_map["FileName"].compare("r_fail") == 0)
-			load_response_post_delete(500);
-		else
-			load_response_post_delete(404);
-	}
-	else
-	{
-		load_response_get(405, path);
 	}
 }
 
@@ -100,6 +106,7 @@ Response::load_response_post_delete(int status_code)
 	_response_map["Status-line"]
 		= _response_map["Protocol"] + _status_code.get_key_value_formated(status_code);
 	set_content_length(_response_map["body-string"]);
+	_response_map["Connection"] = "Closed";
 	construct_header_string();
 	construct_full_response();
 }

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -162,6 +162,7 @@ Response::construct_header_string(void)
 									 + "Content-Length: " + _response_map["Content-Length"] + CRLF
 									 + "Content-Type: " + _response_map["Content-Type"] + CRLF
 									 + "Connection: " + _response_map["Connection"] + CRLF + CRLF;
+	std::cout << "header send :\n" << _response_map["header-string"] << std::endl;
 }
 
 void

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -12,6 +12,10 @@ Response::~Response(void) {}
 void
 Response::load_http_request(Request &request)
 {
+	if (request.error_code != 0)
+	{
+		load_response_post_delete(request.error_code);
+	}
 	init_response_map();
 	std::string path = _dir_path;
 	path += request.get_path();

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -39,16 +39,16 @@ Response::load_http_request(Request &request)
 	}
 	else if (request.get_method().compare("POST") == 0)
 	{
-		if (request._request_map["FileName"].compare("exist") == 0)
+		if (request._request_map["fileStatus"].compare("exist") == 0)
 			load_response_post_delete(409);
 		else
 			load_response_post_delete(201);
 	}
 	else if (request.get_method().compare("DELETE") == 0)
 	{
-		if (request._request_map["FileName"].compare("exist") == 0)
+		if (request._request_map["fileStatus"].compare("exist") == 0)
 			load_response_post_delete(204);
-		else if (request._request_map["FileName"].compare("r_fail") == 0)
+		else if (request._request_map["fileStatus"].compare("r_fail") == 0)
 			load_response_post_delete(500);
 		else
 			load_response_post_delete(404);

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -5,7 +5,7 @@ namespace http
 
 StatusCode Response::_status_code;
 
-Response::Response(void) {}
+Response::Response() : server_name("Webserver") {}
 
 Response::~Response(void) {}
 
@@ -64,7 +64,7 @@ Response::init_response_map()
 {
 	_response_map["Status-line"] = "";
 	_response_map["Date"] = "";
-	_response_map["Server"] = "Webserver";
+	_response_map["Server"] = server_name;
 	_response_map["Content-Length"] = "";
 	_response_map["Content-Type"] = "";
 	_response_map["Connection"] = "Closed";

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -158,7 +158,6 @@ Response::construct_header_string(void)
 									 + "Content-Length: " + _response_map["Content-Length"] + CRLF
 									 + "Content-Type: " + _response_map["Content-Type"] + CRLF
 									 + "Connection: " + _response_map["Connection"] + CRLF + CRLF;
-	std::cout << "header send :\n" << _response_map["header-string"] << std::endl;
 }
 
 void

--- a/src/serverTest/serverTest.cpp
+++ b/src/serverTest/serverTest.cpp
@@ -31,6 +31,7 @@ serverTest(json::t_object *config)
 	unsigned short port = val.get("port").get<double>();
 	std::string	   path = val.get("path").get<std::string>();
 	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, path);
+	sock.set_server_name("Server1");
 
 	create_upload_folder(val);
 	while (1)

--- a/src/serverTest/serverTest.cpp
+++ b/src/serverTest/serverTest.cpp
@@ -30,7 +30,7 @@ serverTest(json::t_object *config)
 	json::Value	   val(config);
 	unsigned short port = val.get("port").get<double>();
 	std::string	   path = val.get("path").get<std::string>();
-	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, path);
+	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, path, ULONG_MAX);
 
 	create_upload_folder(val);
 	while (1)

--- a/src/serverTest/serverTest.cpp
+++ b/src/serverTest/serverTest.cpp
@@ -30,7 +30,7 @@ serverTest(json::t_object *config)
 	json::Value	   val(config);
 	unsigned short port = val.get("port").get<double>();
 	std::string	   path = val.get("path").get<std::string>();
-	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, path);
+	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, path, 10000);
 
 	create_upload_folder(val);
 	while (1)

--- a/src/serverTest/serverTest.cpp
+++ b/src/serverTest/serverTest.cpp
@@ -30,7 +30,7 @@ serverTest(json::t_object *config)
 	json::Value	   val(config);
 	unsigned short port = val.get("port").get<double>();
 	std::string	   path = val.get("path").get<std::string>();
-	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, path, 10000);
+	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, path);
 
 	create_upload_folder(val);
 	while (1)

--- a/src/serverTest/serverTest.cpp
+++ b/src/serverTest/serverTest.cpp
@@ -30,7 +30,7 @@ serverTest(json::t_object *config)
 	json::Value	   val(config);
 	unsigned short port = val.get("port").get<double>();
 	std::string	   path = val.get("path").get<std::string>();
-	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, path, ULONG_MAX);
+	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, path, 10000);
 
 	create_upload_folder(val);
 	while (1)


### PR DESCRIPTION
This feat allows us to set the max content-length if we have one in the config file. It checks if the body size we receive is bigger than content-length and sends a status code error to the client.