### PR TITLE
Configuration file as private attribut

### DIFF
--- a/inc/Response.hpp
+++ b/inc/Response.hpp
@@ -19,7 +19,7 @@ class Response
   public:
 	typedef std::map<std::string, std::string> t_object;
 
-	Response();
+	Response(const json::Value &server_config);
 	~Response(void);
 	std::string		server_name;
 	std::string		get_http_response(void);
@@ -28,14 +28,15 @@ class Response
 	void			set_dir_path(std::string);
 
   private:
-	static StatusCode _status_code;
-	t_object		  _response_map;
-	std::string		  _dir_path;
-	void			  set_content_length(std::string str);
-	void			  init_response_map(void);
-	void			  set_response_type(std::string path);
-	void			  load_response_get(int status_code, const std::string &path);
-	void			  load_response_post_delete(int status_code);
+	const json::Value &_server_config;
+	static StatusCode  _status_code;
+	t_object		   _response_map;
+	std::string		   _dir_path;
+	void			   set_content_length(std::string str);
+	void			   init_response_map(void);
+	void			   set_response_type(std::string path);
+	void			   load_response_get(int status_code, const std::string &path);
+	void			   load_response_post_delete(int status_code);
 
 	std::string get_time_stamp(void);
 	void		construct_header_string(void);

--- a/inc/Socket.hpp
+++ b/inc/Socket.hpp
@@ -22,6 +22,7 @@
 class Socket
 {
   private:
+	const json::Value &_server_config;
 	http::Request	   _request;
 	http::Response	   _response;
 	std::string		   _header_str;
@@ -48,7 +49,7 @@ class Socket
 	void			   check_content_lenght_authorized();
 
   public:
-	Socket(int domain, unsigned short port, int type, int protocol, std::string path,
+	Socket(int domain, unsigned short port, int type, int protocol, const json::Value &,
 		   unsigned long max_length = ULONG_MAX);
 	int	 socket_recv();
 	void socket_accept();

--- a/inc/Value.hpp
+++ b/inc/Value.hpp
@@ -37,6 +37,8 @@ class Value
 	enum e_type get_type(void) const;
 	Value	   &get(std::string const &) const;
 
+	void duplicate(t_object const &);
+
 	/* templates functions */
 	template <typename T> T &get(void) const;
 

--- a/src/Socket/Socket.cpp
+++ b/src/Socket/Socket.cpp
@@ -1,8 +1,8 @@
 #include "Socket.hpp"
 
-Socket::Socket(int domain, unsigned short port, int type, int protocol, std::string path,
+Socket::Socket(int domain, unsigned short port, int type, int protocol, const json::Value &server_config,
 			   unsigned long max_length)
-	: _max_content_length(max_length)
+	: _server_config(server_config), _response(server_config), _max_content_length(max_length)
 {
 	_address.sin_family = domain;
 	_address.sin_port = htons(port);
@@ -13,7 +13,7 @@ Socket::Socket(int domain, unsigned short port, int type, int protocol, std::str
 	start_listening();
 	_header_str = "";
 	_body_str = "";
-	_dir_path = path;
+	_dir_path = _server_config.get("path").get<std::string>();
 	_response.set_dir_path(_dir_path);
 }
 

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -5,7 +5,7 @@ namespace http
 
 StatusCode Response::_status_code;
 
-Response::Response(const json::Value &server_config) : server_name("Webserver"), _server_config(server_config) {}
+Response::Response(const json::Value &server_config) : server_name("Webserver"), _server_config(server_config) {(void) _server_config;}
 
 Response::~Response(void) {}
 

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -5,7 +5,7 @@ namespace http
 
 StatusCode Response::_status_code;
 
-Response::Response() : server_name("Webserver") {}
+Response::Response(const json::Value &server_config) : server_name("Webserver"), _server_config(server_config) {}
 
 Response::~Response(void) {}
 

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -5,7 +5,10 @@ namespace http
 
 StatusCode Response::_status_code;
 
-Response::Response(const json::Value &server_config) : server_name("Webserver"), _server_config(server_config) {(void) _server_config;}
+Response::Response(const json::Value &server_config) : server_name("Webserver"), _server_config(server_config)
+{
+	(void)_server_config;
+}
 
 Response::~Response(void) {}
 

--- a/src/json/Value.cpp
+++ b/src/json/Value.cpp
@@ -117,6 +117,15 @@ Value::get(std::string const &key) const
 	return get<t_object>().at(key);
 }
 
+void
+Value::duplicate(t_object const &object)
+{
+	delete_value();
+
+	_value = new t_object(object);
+	_type = JSON_OBJECT;
+}
+
 /* extra */
 
 std::ostream &

--- a/src/json/check_config.cpp
+++ b/src/json/check_config.cpp
@@ -8,14 +8,14 @@ namespace json
 {
 
 static int
-check_value_servername(t_object *config)
+check_value_servername(t_object &config)
 {
-	if (config->find("server_name") == config->end())
+	if (config.find("server_name") == config.end())
 	{
-		(*config)["server_name"] = json::Value(new std::string(DEFAULT_SERVER_NAME));
+		config["server_name"] = json::Value(new std::string(DEFAULT_SERVER_NAME));
 		return 0;
 	}
-	else if (config->at("server_name").get_type() != JSON_STRING)
+	else if (config.at("server_name").get_type() != JSON_STRING)
 	{
 		std::cerr << "Error: the server_name is not a string" << std::endl;
 		return 1;
@@ -24,14 +24,14 @@ check_value_servername(t_object *config)
 }
 
 static int
-check_value_path(t_object *config)
+check_value_path(t_object const &config)
 {
-	if (config->find("path") == config->end())
+	if (config.find("path") == config.end())
 	{
 		std::cerr << "Error: not path in the config" << std::endl;
 		return 1;
 	}
-	if (config->at("path").get_type() != JSON_STRING)
+	if (config.at("path").get_type() != JSON_STRING)
 	{
 		std::cerr << "Error: the path is not a string" << std::endl;
 		return 1;
@@ -40,19 +40,19 @@ check_value_path(t_object *config)
 }
 
 static int
-check_value_port(t_object *config)
+check_value_port(t_object const &config)
 {
-	if (config->find("port") == config->end())
+	if (config.find("port") == config.end())
 	{
 		std::cerr << "Error: not port in the config" << std::endl;
 		return 1;
 	}
-	if (config->at("port").get_type() != JSON_NUMBER)
+	if (config.at("port").get_type() != JSON_NUMBER)
 	{
 		std::cerr << "Error: the port is not a number" << std::endl;
 		return 1;
 	}
-	double port(config->at("port").get<double>());
+	double port(config.at("port").get<double>());
 	if (port < 0 || USHRT_MAX < port)
 	{
 		std::cerr << "Error: port over-range" << std::endl;
@@ -66,12 +66,18 @@ check_value_port(t_object *config)
 int
 check_config(t_object *config)
 {
-	if (check_value_path(config))
-		return 1;
-	if (check_value_port(config))
-		return 1;
-	if (check_value_servername(config))
-		return 1;
+	for (t_object::iterator server_config(config->begin()); server_config != config->end(); ++server_config)
+	{
+		if (server_config->second.get_type() == JSON_OBJECT)
+		{
+			if (check_value_path(server_config->second.get<t_object>()))
+				return 1;
+			if (check_value_port(server_config->second.get<t_object>()))
+				return 1;
+			if (check_value_servername(server_config->second.get<t_object>()))
+				return 1;
+		}
+	}
 
 	return 0;
 }

--- a/src/serverTest/serverTest.cpp
+++ b/src/serverTest/serverTest.cpp
@@ -29,7 +29,7 @@ serverTest(json::t_object *config)
 	 */
 	json::Value	   val(config);
 	unsigned short port = val.get("port").get<double>();
-	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, val, 100000);
+	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, val);
 	sock.set_server_name("Server1");
 
 	create_upload_folder(val);

--- a/src/serverTest/serverTest.cpp
+++ b/src/serverTest/serverTest.cpp
@@ -28,7 +28,8 @@ serverTest(json::t_object *config)
 	 *	address for this socket, let the OS choose = INADDR_ANY
 	 */
 	json::Value val(config);
-	json::Value server_config(&(val.get("foo.com").get<json::t_object>()));
+	json::Value server_config;
+	server_config.duplicate(val.get("foo.com").get<json::t_object>());
 	std::cout << server_config << std::endl;
 	unsigned short port = val.get("port").get<double>();
 	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, val);

--- a/src/serverTest/serverTest.cpp
+++ b/src/serverTest/serverTest.cpp
@@ -29,8 +29,7 @@ serverTest(json::t_object *config)
 	 */
 	json::Value	   val(config);
 	unsigned short port = val.get("port").get<double>();
-	std::string	   path = val.get("path").get<std::string>();
-	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, path, 100000);
+	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, val, 100000);
 	sock.set_server_name("Server1");
 
 	create_upload_folder(val);

--- a/src/serverTest/serverTest.cpp
+++ b/src/serverTest/serverTest.cpp
@@ -27,11 +27,14 @@ serverTest(json::t_object *config)
 	 *	AF_INET + SOCK_STREAM always protocol = 0,
 	 *	address for this socket, let the OS choose = INADDR_ANY
 	 */
-	json::Value	   val(config);
+	json::Value val(config);
+	json::Value server_config(&(val.get("foo.com").get<json::t_object>()));
+	std::cout << server_config << std::endl;
 	unsigned short port = val.get("port").get<double>();
 	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, val);
 	sock.set_server_name("Server1");
 
+	return;
 	create_upload_folder(val);
 	while (1)
 	{

--- a/src/serverTest/serverTest.cpp
+++ b/src/serverTest/serverTest.cpp
@@ -30,7 +30,7 @@ serverTest(json::t_object *config)
 	json::Value	   val(config);
 	unsigned short port = val.get("port").get<double>();
 	std::string	   path = val.get("path").get<std::string>();
-	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, path);
+	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, path, 100000);
 	sock.set_server_name("Server1");
 
 	create_upload_folder(val);

--- a/src/serverTest/serverTest.cpp
+++ b/src/serverTest/serverTest.cpp
@@ -31,8 +31,8 @@ serverTest(json::t_object *config)
 	json::Value server_config;
 	server_config.duplicate(val.get("foo.com").get<json::t_object>());
 	std::cout << server_config << std::endl;
-	unsigned short port = val.get("port").get<double>();
-	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, val);
+	unsigned short port = server_config.get("port").get<double>();
+	Socket		   sock(AF_INET, port, SOCK_STREAM, 0, server_config);
 	sock.set_server_name("Server1");
 
 	return;

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -17,7 +17,5 @@ webserver(const char *path_config_file)
 
 	serverTest(config);
 
-	delete config;
-
 	return 0;
 }


### PR DESCRIPTION
### config as private const reference attribut

#### Purpose:

add the configuration file as private attribut

* json: duplicate
* `json::check()` adapt to config.json
* serverTest.cpp: adapt for config.json

#### TODO:

* [ ] remove this line
  ```cpp
  (void) _server_config
  ```
* [ ] use the config instead of `std::string path`
* [ ] tdd: update `json::check_config()`
