### PR TITLE
main: default configuration file

### DIFF
--- a/src/arguments/check_argc_number.cpp
+++ b/src/arguments/check_argc_number.cpp
@@ -12,7 +12,7 @@ print_help(void)
 int
 check_argc_number(int argc)
 {
-	if (argc == 2)
+	if (argc < 3)
 		return 0;
 
 	print_help();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,14 +1,26 @@
 #include "arguments.hpp"
 #include "webserver.hpp"
 
+#define DEFAULT_CONFIG "./config.json"
+
 int
 main(int argc, char **argv)
 {
 	if (arguments::check_argc_number(argc))
 		return 1;
 
-	if (arguments::check_argv_access(argv[1]))
-		return 1;
+	if (argc == 2)
+	{
+		if (arguments::check_argv_access(argv[1]))
+			return 1;
 
-	return webserver(argv[1]);
+		return webserver(argv[1]);
+	}
+	else if (argc == 1)
+	{
+		if (arguments::check_argv_access(DEFAULT_CONFIG))
+			return 1;
+
+		return webserver(DEFAULT_CONFIG);
+	}
 }

--- a/test/src/arguments-argc/01_test.cpp
+++ b/test/src/arguments-argc/01_test.cpp
@@ -11,7 +11,7 @@ test_check_argc_number_1(void)
 	output.open();
 
 	/* run the function to test */
-	fresutl = arguments::check_argc_number(1);
+	fresutl = arguments::check_argc_number(3);
 
 	output.close();
 


### PR DESCRIPTION
# main: default configuration file

default configuration file

## Why ?

From the subject:

> Votre programme doit prendre un fichier de
> configuration en argument ou utiliser un
> chemin par défaut
