### PR TITLE
remove ugly dev print

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -12,8 +12,6 @@ webserver(const char *path_config_file)
 	if (json::load_config(path_config_file, &config))
 		return 1;
 
-	std::cout << *config << std::endl;
-
 	Cluster cluster;
 	cluster.load_cluster(config);
 	cluster.setup();


### PR DESCRIPTION
# remove **ugly** dev print

:red_circle: Before
```
Web server written in C++98
{"docs.com" : {"path" : "./docs", "port" : 8082, "server_name" :
"default_server_name"}, "dummywebsite.com" : {"405" : "405.html", "dir_error" :
"is_dir.html", "method_allowed" : {"/index.html" : 1}, "path" :
"./test/website2", "port" : 8080, "server_name" : "default_server_name"},
"nicesite.com" : {"method_allowed" : {"/index.html" : 1, "/path/two" : 3,
"/uploads" : 7}, "path" : "./test/website", "port" : 8081, "redirection" :
{"/site_duck" : "duckduckgo.com", "/site_sheep" : "google.com"}, "server_name" :
"default_server_name"}, "php-cgi" : "/path/of/php-cgi"}
:8082 set up
:8080 set up
:8081 set up
++++++ Waiting for new connection ++++++
```

:green_circle: After
```
Web server written in C++98
:8082 set up
:8080 set up
:8081 set up
++++++ Waiting for new connection ++++++
```
