### PR TITLE
Socket::body_handler(), Socket::has_php_extension()

### DIFF
--- a/inc/Socket.hpp
+++ b/inc/Socket.hpp
@@ -44,6 +44,8 @@ class Socket
 	void			   create_new_file();
 	std::string		   clean_end_of_file(std::string const &str_to_clean);
 	void			   check_content_lenght_authorized();
+	void			   body_handler();
+	bool			   has_php_extension() const;
 
   public:
 	Socket(int domain, unsigned short port, int type, int protocol, const json::Value &);

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -20,7 +20,7 @@ Response::load_http_request(Request &request)
 	}
 	std::string path = _server_config.get("path").get<std::string>();
 	path += request.get_path();
-	if (has_php_extension(request) && (request.get_method().compare("POST") != 0))
+	if (has_php_extension(request))
 	{
 		if (access(path.c_str(), F_OK))
 			load_response_with_path(404, path);

--- a/test/src/check-json-config/01_test.cpp
+++ b/test/src/check-json-config/01_test.cpp
@@ -1,6 +1,6 @@
 #include "Stream.hpp"
-#include "utils_json.hpp"
 #include "setting.hpp"
+#include "utils_json.hpp"
 
 int
 test_json_check_config_normal(void)


### PR DESCRIPTION
Changes in Sockets:
- only one path for POST (before 2, one for multipart, and one for CGI)
- multipart_handler only receives all the content body and then calls body_handler()
- body_handler check the content type:
- if multipart -> create file;
- if text/plain -> print it and send 202 (accepted) response OR if for cgi -> php_handler()
- else refuse any other type send 415 (Unsupported Media Type)