### PR TITLE
cgi: cgi path attribute

### DIFF
--- a/inc/cgi.hpp
+++ b/inc/cgi.hpp
@@ -40,6 +40,8 @@ class CGI
 	std::string _script_name;
 	std::string _query;
 
+	static std::string _path_php_binary;
+
   public:
 	CGI(void);
 	CGI(const std::string &bin, const std::string &file, const std::string &query);
@@ -49,6 +51,9 @@ class CGI
 	void		child_process(char **);
 	void		set_env(const std::map<std::string, std::string> &map, const std::string &args);
 	void		check_map(const std::map<std::string, std::string> &map, const std::string &name_file);
+
+	static void set_php_binary(std::string const &);
+
 	~CGI(void);
 };
 

--- a/src/cgi/execve.cpp
+++ b/src/cgi/execve.cpp
@@ -6,6 +6,8 @@
 
 #define BUFFER_SIZE 4092
 
+std::string CGI::_path_php_binary = "";
+
 std::string
 get_query(const std::map<std::string, std::string> &map)
 {
@@ -53,8 +55,8 @@ CGI::check_map(const std::map<std::string, std::string> &map, const std::string 
 	/*----- SCRIPT_NAME -----*/
 	struct stat sa = {};
 	_script_name = "";
-	if (stat("/Users/kdi-noce/goinfre/php/php-8.2.5/sapi/cgi/php-cgi", &sa) == 0)
-		_script_name = "/Users/kdi-noce/goinfre/php/php-8.2.5/sapi/cgi/php-cgi";
+	if (stat(_path_php_binary, &sa) == 0)
+		_script_name = _path_php_binary;
 
 	std::map<std::string, std::string>::const_iterator it = map.find("Path");
 	/*----- SCRIPT_FILENAME -----*/
@@ -86,6 +88,12 @@ CGI::check_map(const std::map<std::string, std::string> &map, const std::string 
 	set_private_attribute(map.find("Server-Protocole"), map.end(), _http_version);
 	/*----- SERVER_PORT -----*/
 	set_private_attribute(map.find("Port"), map.end(), _port);
+}
+
+void
+CGI::set_php_binary(std::string const &path_binary)
+{
+	_path_php_binary = path_binary;
 }
 
 /*

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -1,4 +1,5 @@
 #include "Json.hpp"
+#include "cgi.hpp"
 #include "cluster.hpp"
 #include <iostream>
 
@@ -14,6 +15,8 @@ webserver(const char *path_config_file)
 		delete config;
 		return 1;
 	}
+
+	CGI::set_php_binary(config->at("php-cgi").get<std::string>());
 
 	Cluster cluster;
 	cluster.load_cluster(config);


### PR DESCRIPTION
# CGI: new static private attribute

* create _path_php_binary as static private attribute
* create set_php_binary(string) as static public method
* replace hard coded path with a variable
  setted by the configuration file
* webserver.cpp set the _path_php_binary
