### PR TITLE
fix compilation error

### DIFF
--- a/src/cgi/execve.cpp
+++ b/src/cgi/execve.cpp
@@ -55,7 +55,7 @@ CGI::check_map(const std::map<std::string, std::string> &map, const std::string 
 	/*----- SCRIPT_NAME -----*/
 	struct stat sa = {};
 	_script_name = "";
-	if (stat(_path_php_binary, &sa) == 0)
+	if (stat(_path_php_binary.c_str(), &sa) == 0)
 		_script_name = _path_php_binary;
 
 	std::map<std::string, std::string>::const_iterator it = map.find("Path");


### PR DESCRIPTION
# Fix compilation error

```
src/cgi/execve.cpp: In member function ‘void CGI::check_map(const std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >&, const std::string&)’:
src/cgi/execve.cpp:58:18: error: cannot convert ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘const char*’
   58 |         if (stat(_path_php_binary, &sa) == 0)
      |                  ^~~~~~~~~~~~~~~~
      |                  |
      |                  std::string {aka std::__cxx11::basic_string<char>}
compilation terminated due to -Wfatal-errors.
```
